### PR TITLE
Fix the function of skipping properties in Story class

### DIFF
--- a/model/story.py
+++ b/model/story.py
@@ -17,6 +17,6 @@ class Story(Media):
         super(Story, self).__init__(props)
 
     def _init_properties_custom(self, value, prop, dictionary=None):
-        if self.__skip_prop:
+        if prop in self.__skip_prop.keys() and self.__skip_prop[prop]:
             return False
         super(Story, self)._init_properties_custom(value, prop, dictionary)


### PR DESCRIPTION
If I create an instance of Story class, no matter what is included in the prop dict, all of the properties in the instance are still the default values.

Test code:
>>> from model.story import Story
>>> t = Story({'id':1})
>>> t._id